### PR TITLE
Add write permissions for issues in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  issues: write
 
 env:
   ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}


### PR DESCRIPTION
This pull request introduces a small configuration change to the GitHub Actions workflow. The update grants the workflow permission to write to GitHub Issues, which may be needed for automations or reporting.

* Added `issues: write` permission to the workflow in `.github/workflows/cd.yml` to enable the workflow to create or update GitHub Issues.